### PR TITLE
Fix missing newlines in MPEG segments

### DIFF
--- a/src/DBClass.cpp
+++ b/src/DBClass.cpp
@@ -202,10 +202,10 @@ void DBClass::doDirectoryMode2(FILE *fp, int dirIndex, int level)
 					fprintf(fp, "%s    MpegMultiplex\n", space);
 					fprintf(fp, "%s        MpegStream \"%s.M1V\" VIDEO\n", space, basefile);
 					fprintf(fp, "%s            BitRate %d.0\n", space, 1150000);
-					fprintf(fp, "%s        EndMpegStream", space);
+					fprintf(fp, "%s        EndMpegStream\n", space);
 					fprintf(fp, "%s        MpegStream \"%s.MP2\" AUDIO\n", space, basefile);
 					fprintf(fp, "%s            BitRate %d.0\n", space, 192000);
-					fprintf(fp, "%s        EndMpegStream", space);
+					fprintf(fp, "%s        EndMpegStream\n", space);
 					fprintf(fp, "%s    EndMpegMultiplex\n", space);
 				}
 				else


### PR DESCRIPTION
This fixes a bug I noticed where a few newlines were missing in the MPEG segment of a track, resulting in a malformed `MpegMultiplex` statement.

Before:

```
                MpegMultiplex
                    MpegStream "AN000.M1V" VIDEO
                        BitRate 1150000.0
                    EndMpegStream                    MpegStream "AN000.MP2" AUDIO
                        BitRate 192000.0
                    EndMpegStream                EndMpegMultiplex
```

After:

```
                MpegMultiplex
                    MpegStream "Files\AN000.M1V" VIDEO
                        BitRate 1150000.0
                    EndMpegStream
                    MpegStream "Files\AN000.MP2" AUDIO
                        BitRate 192000.0
                    EndMpegStream
                EndMpegMultiplex
```