### PR TITLE
Use mkdir instead of system("mkdir %s")

### DIFF
--- a/src/ISOExtract.cpp
+++ b/src/ISOExtract.cpp
@@ -1590,11 +1590,9 @@ enum errorcode ISOExtractClass::importDisc(const char *filename, const char *dir
    else
       goto error;
 
-   char command[PATH_MAX*2];
    char path[PATH_MAX];
    realpath(dir, path);
-   sprintf(command, "mkdir %s", path);
-   system(command); 
+   mkdir(path); 
 
    if (!extractIP(dir))
       goto error;


### PR DESCRIPTION
`mkdir` is consistently used elsewhere, and this `system` command introduces bugs involving directory names which contain spaces.