### PR TITLE
Fixed issue with Batman Arcade game

### DIFF
--- a/src/ISOExtract.cpp
+++ b/src/ISOExtract.cpp
@@ -639,7 +639,7 @@ enum errorcode ISOExtractClass::extractFiles(dirrec_struct *dirrec, uint32_t num
                int offset = dirrec[i].LocationOfExtentL - cdinfo.trackinfo[trackindex].fileoffset + (i2 / 2048);
                if (!readUserSector(offset, sector, &readsize, track, &sectorinfo))
                {
-                  printf("WARNING: Could not read User sector for file:  SKIPPING\n");
+                  printf("\nWARNING: Could not read User sector for file: %s  SKIPPING\n\n", dirrec[i].FileIdentifier);
                   // err = ERR_READ;
                   // goto error;
                   break;

--- a/src/ISOExtract.cpp
+++ b/src/ISOExtract.cpp
@@ -29,9 +29,6 @@
 #include <errno.h>
 #include "ISOExtract.h"
 #include "iso.h"
-#include <string>
-#include <sstream>
-#include <iostream>
 
 #ifndef _WIN32
 #include <utime.h>


### PR DESCRIPTION
There were two issues, the first probably caused by my compiler (clang) needed to put parenthesis around the subtraction before the devision. The second is to warn when an invalid file is found (in Batman's case it is a file called `CDDA1;1` rather than failing, so that the rest of the files can be extracted.